### PR TITLE
Add a signal that enables CORS headers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,28 @@ Note that ``CorsMiddleware`` needs to come before Django’s
 setting, otherwise the CORS headers will be lost from the 304
 not-modified responses, causing errors in some browsers.
 
+Signals
+-------
+
+If you have a use-case that requires running Python code to check if a site exists,
+we provide a Django signal that covers this.
+We have a ``check_request_enabled`` signal that provides the request.
+Here is an example configuration::
+
+    from corsheaders import signals
+    from .models import Site
+
+    def handler(sender, request, **kwargs):
+        for site in Site.objects.all():
+            if request.host in site.domain:
+                return True
+        return False
+
+    signals.check_request_enabled.connect(handler)
+
+If the signal returns ``True``,
+then the request will have headers added to it.
+
 Configuration
 -------------
 

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -160,7 +160,9 @@ class CorsMiddleware(object):
             self.check_signal(request)
 
     def check_signal(self, request):
-        signal_response = signals.check_request_enabled.send(sender=None, request=request)
+        signal_response = signals.check_request_enabled.send(
+            sender=None, request=request
+        )
         for function, return_value in signal_response:
             if return_value:
                 return True

--- a/corsheaders/models.py
+++ b/corsheaders/models.py
@@ -1,8 +1,8 @@
 from django.db import models
 
+# For signal registration
+from .signals import check_request_enabled  # noqa
+
 
 class CorsModel(models.Model):
     cors = models.CharField(max_length=255)
-
-# For model registration
-from .signals import check_request_enabled

--- a/corsheaders/models.py
+++ b/corsheaders/models.py
@@ -3,3 +3,6 @@ from django.db import models
 
 class CorsModel(models.Model):
     cors = models.CharField(max_length=255)
+
+# For model registration
+from .signals import check_request_enabled

--- a/corsheaders/signals.py
+++ b/corsheaders/signals.py
@@ -1,0 +1,7 @@
+import django.dispatch
+
+# Return Truthy values to enable a specific request.
+# This allows users to build custom logic into the request handling
+check_request_enabled = django.dispatch.Signal(
+    providing_args=["request"]
+)


### PR DESCRIPTION
If you have a use-case that requires running Python code to check if a site exists,
we provide a Django signal that covers this.
We have a `check_request_enabled` signal that provides the request.
Here is an example configuration::

```
from corsheaders import signals
from .models import Site

def handler(sender, request, **kwargs):
    for site in Site.objects.all():
        if request.host in site.domain:
            return True
    return False

signals.check_request_enabled.connect(handler)
```

If the signal returns `True`,
then the request will have headers added to it.
